### PR TITLE
Weight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,12 @@
 /tr/knitr-figs
 /tr/knitr-cache
 /tr/cache
+/tr/SpawnIndex.aux
 /tr/SpawnIndex.bbl
 /tr/SPawnIndex.lof
 /tr/SPawnIndex.log
 /tr/SPawnIndex.txt
+/tr/SpawnIndex.out
 /tr/SPawnIndex.pdf
 /tr/SPawnIndex.tex
 /tr/SPawnIndex.toc

--- a/R/calcs.R
+++ b/R/calcs.R
@@ -770,8 +770,7 @@ CalcUnderSpawn <- function(where,
       Year, Region, StatArea, Section, LocationCode, SpawnNumber, Transect
     ) %>%
     # Transect t
-    dplyr::summarise(EggDensL = gfiscamutils::MeanNA(EggDens) *
-      unique(Width)) %>%
+    dplyr::summarise(EggDens = gfiscamutils::MeanNA(EggDens)) %>%
     dplyr::ungroup()
   # Calculate spawn number-level metrics
   eggsSpawn <- eggsTrans %>%
@@ -793,14 +792,14 @@ CalcUnderSpawn <- function(where,
     dplyr::summarise(
       WidthTot = unique(WidthTot), WidthBar = unique(WidthBar),
       LengthAlgae = unique(LengthAlgae),
-      EggDensL = gfiscamutils::SumNA(EggDensL)
+      EggDens = gfiscamutils::WtMeanNA(EggDens, w=Width)
     ) %>%
     dplyr::ungroup()
   # Calculate understory biomass by spawn number
   biomassSpawn <- eggsSpawn %>%
     dplyr::mutate(
       # Weighted egg density in thousands (eggs * 10^3 / m^2); spawn s
-      EggDens = EggDensL / WidthTot,
+      # EggDens = EggDensL / WidthTot,
       # Biomass in tonnes, based on Hay (1985), and Hay and Brett (1988); spawn
       # s
       UnderSI = EggDens * LengthAlgae * WidthBar * 1000 / theta

--- a/R/calcs.R
+++ b/R/calcs.R
@@ -770,7 +770,8 @@ CalcUnderSpawn <- function(where,
       Year, Region, StatArea, Section, LocationCode, SpawnNumber, Transect
     ) %>%
     # Transect t
-    dplyr::summarise(EggDensL = gfiscamutils::WtMeanNA(EggDens, w=Width)) %>%
+    dplyr::summarise(EggDensL = gfiscamutils::MeanNA(EggDens) *
+                       unique(Width)) %>%
     dplyr::ungroup()
   # Calculate spawn number-level metrics
   eggsSpawn <- eggsTrans %>%
@@ -802,7 +803,7 @@ CalcUnderSpawn <- function(where,
       EggDens = EggDensL / WidthTot,
       # Biomass in tonnes, based on Hay (1985), and Hay and Brett (1988); spawn
       # s
-      UnderSI = EggDensL * LengthAlgae * WidthBar * 1000 / theta
+      UnderSI = EggDens * LengthAlgae * WidthBar * 1000 / theta
     ) %>%
     dplyr::left_join(y = eggLyrs, by = c("Year", "LocationCode", "SpawnNumber"))
   # Calculate understory SI by spawn number

--- a/R/calcs.R
+++ b/R/calcs.R
@@ -199,7 +199,7 @@ CalcSurfSpawn <- function(where,
       EggLyrs = Grass + Rockweed + Kelp + BrownAlgae + LeafyRed +
         StringyRed + Rock + Other,
       Intensity = ifelse(Year %in% rsYrs & Intensity > 0,
-                         Intensity * 2 - 1, Intensity
+        Intensity * 2 - 1, Intensity
       )
     ) %>%
     dplyr::filter(Method %in% c("Surface", "Dive")) %>%
@@ -212,7 +212,7 @@ CalcSurfSpawn <- function(where,
     dplyr::mutate(
       # SoG (1 record): update Intensity from 0 to 1 (surveyed but not reported)
       Intensity = ifelse(Year == 1962 & StatArea == 14 & Section == 142 &
-                           LocationCode == 820 & Intensity == 0, 1, Intensity)
+        LocationCode == 820 & Intensity == 0, 1, Intensity)
     )
   # Calculate egg density based on intensity or direct measurements
   eggs <- surface %>%
@@ -255,8 +255,8 @@ CalcSurfSpawn <- function(where,
   # Error if there are missing values
   if (nrow(noLayers) > 0) {
     stop("Missing egg layers for ", nrow(noLayers), " record(s):",
-         print(noLayers),
-         sep = ""
+      print(noLayers),
+      sep = ""
     )
   }
   # Output egg layer info
@@ -679,10 +679,10 @@ CalcUnderSpawn <- function(where,
   if (any(!algae$AlgType %in% algCoefs$AlgType)) {
     # Get missing algae type(s)
     missAlg <- unique(algae$AlgType[!algae$AlgType %in%
-                                      algCoefs$AlgType])
+      algCoefs$AlgType])
     # Error, and show missing type(s)
     stop("Missing algae type(s): ", paste(missAlg, collapse = ", "),
-         call. = FALSE
+      call. = FALSE
     )
   } # End if there are missing algae types
   # Get a small subset of area data
@@ -724,7 +724,7 @@ CalcUnderSpawn <- function(where,
     # size coefficients not required because all quadrats are 0.5m^2 (1.0512)
     # Algae a
     dplyr::mutate(EggDensAlg = beta * AlgLyrs^gamma * AlgProp^delta * Coef *
-                    1.0512) %>%
+      1.0512) %>%
     dplyr::group_by(
       Year, Region, StatArea, Section, LocationCode, SpawnNumber, Transect,
       Station
@@ -771,7 +771,7 @@ CalcUnderSpawn <- function(where,
     ) %>%
     # Transect t
     dplyr::summarise(EggDensL = gfiscamutils::MeanNA(EggDens) *
-                       unique(Width)) %>%
+      unique(Width)) %>%
     dplyr::ungroup()
   # Calculate spawn number-level metrics
   eggsSpawn <- eggsTrans %>%
@@ -780,7 +780,7 @@ CalcUnderSpawn <- function(where,
       by = c("Year", "LocationCode", "SpawnNumber")
     ) %>%
     dplyr::mutate(LengthAlgae = ifelse(is.na(LengthAlgae), Length,
-                                       LengthAlgae
+      LengthAlgae
     )) %>%
     dplyr::filter(Method %in% c("Surface", "Dive")) %>%
     dplyr::left_join(y = widths, by = c(

--- a/R/calcs.R
+++ b/R/calcs.R
@@ -760,7 +760,6 @@ CalcUnderSpawn <- function(where,
     ) %>%
     # Spawn s
     dplyr::summarise(
-      WidthTot = gfiscamutils::SumNA(Width),
       WidthBar = gfiscamutils::MeanNA(Width)
     ) %>%
     dplyr::ungroup()
@@ -792,16 +791,14 @@ CalcUnderSpawn <- function(where,
     ) %>%
     # Spawn s
     dplyr::summarise(
-      WidthTot = unique(WidthTot), WidthBar = unique(WidthBar),
+      WidthBar = unique(WidthBar),
       LengthAlgae = unique(LengthAlgae),
-      EggDens = gfiscamutils::WtMeanNA(EggDens, w=Width)
+      EggDens = gfiscamutils::WtMeanNA(EggDens, w = Width)
     ) %>%
     dplyr::ungroup()
   # Calculate understory biomass by spawn number
   biomassSpawn <- eggsSpawn %>%
     dplyr::mutate(
-      # Weighted egg density in thousands (eggs * 10^3 / m^2); spawn s
-      # EggDens = EggDensL / WidthTot,
       # Biomass in tonnes, based on Hay (1985), and Hay and Brett (1988); spawn
       # s
       UnderSI = EggDens * LengthAlgae * WidthBar * 1000 / theta

--- a/R/calcs.R
+++ b/R/calcs.R
@@ -562,7 +562,6 @@ CalcMacroSpawn <- function(where,
 #'   where = underLoc, a = areas, yrs = 2010:2015
 #' )
 #' underSpawn$SI
-#' readr::write_csv(x = underSpawn$SI, path = "under.csv")
 CalcUnderSpawn <- function(where,
                            a,
                            yrs,

--- a/R/calcs.R
+++ b/R/calcs.R
@@ -562,6 +562,7 @@ CalcMacroSpawn <- function(where,
 #'   where = underLoc, a = areas, yrs = 2010:2015
 #' )
 #' underSpawn$SI
+#' readr::write_csv(x = underSpawn$SI, path = "under.csv")
 CalcUnderSpawn <- function(where,
                            a,
                            yrs,
@@ -770,7 +771,8 @@ CalcUnderSpawn <- function(where,
       Year, Region, StatArea, Section, LocationCode, SpawnNumber, Transect
     ) %>%
     # Transect t
-    dplyr::summarise(EggDens = gfiscamutils::MeanNA(EggDens)) %>%
+    dplyr::summarise(EggDens = gfiscamutils::MeanNA(EggDens),
+                     Width = unique(Width)) %>%
     dplyr::ungroup()
   # Calculate spawn number-level metrics
   eggsSpawn <- eggsTrans %>%

--- a/R/calcs.R
+++ b/R/calcs.R
@@ -745,7 +745,7 @@ CalcUnderSpawn <- function(where,
     dplyr::mutate(EggDensSub = ifelse(Width > 0, EggDensSub, 0))
   # Calculate total egg density by station/quadrat
   eggsStation <- eggs %>%
-    # Total egg density in thousands (eggs * 10^3 / m); quadrat q
+    # Total egg density in thousands (eggs * 10^3 / m^2); quadrat q
     dplyr::mutate(EggDens = EggDensSub + EggDensAlg) %>%
     dplyr::filter(!is.na(Station))
   # Widths
@@ -770,8 +770,7 @@ CalcUnderSpawn <- function(where,
       Year, Region, StatArea, Section, LocationCode, SpawnNumber, Transect
     ) %>%
     # Transect t
-    dplyr::summarise(EggDensL = gfiscamutils::MeanNA(EggDens) *
-      unique(Width)) %>%
+    dplyr::summarise(EggDensL = gfiscamutils::WtMeanNA(EggDens, w=Width)) %>%
     dplyr::ungroup()
   # Calculate spawn number-level metrics
   eggsSpawn <- eggsTrans %>%
@@ -803,7 +802,7 @@ CalcUnderSpawn <- function(where,
       EggDens = EggDensL / WidthTot,
       # Biomass in tonnes, based on Hay (1985), and Hay and Brett (1988); spawn
       # s
-      UnderSI = EggDens * LengthAlgae * WidthBar * 1000 / theta
+      UnderSI = EggDensL * LengthAlgae * WidthBar * 1000 / theta
     ) %>%
     dplyr::left_join(y = eggLyrs, by = c("Year", "LocationCode", "SpawnNumber"))
   # Calculate understory SI by spawn number

--- a/R/calcs.R
+++ b/R/calcs.R
@@ -199,7 +199,7 @@ CalcSurfSpawn <- function(where,
       EggLyrs = Grass + Rockweed + Kelp + BrownAlgae + LeafyRed +
         StringyRed + Rock + Other,
       Intensity = ifelse(Year %in% rsYrs & Intensity > 0,
-        Intensity * 2 - 1, Intensity
+                         Intensity * 2 - 1, Intensity
       )
     ) %>%
     dplyr::filter(Method %in% c("Surface", "Dive")) %>%
@@ -212,7 +212,7 @@ CalcSurfSpawn <- function(where,
     dplyr::mutate(
       # SoG (1 record): update Intensity from 0 to 1 (surveyed but not reported)
       Intensity = ifelse(Year == 1962 & StatArea == 14 & Section == 142 &
-        LocationCode == 820 & Intensity == 0, 1, Intensity)
+                           LocationCode == 820 & Intensity == 0, 1, Intensity)
     )
   # Calculate egg density based on intensity or direct measurements
   eggs <- surface %>%
@@ -255,8 +255,8 @@ CalcSurfSpawn <- function(where,
   # Error if there are missing values
   if (nrow(noLayers) > 0) {
     stop("Missing egg layers for ", nrow(noLayers), " record(s):",
-      print(noLayers),
-      sep = ""
+         print(noLayers),
+         sep = ""
     )
   }
   # Output egg layer info
@@ -679,10 +679,10 @@ CalcUnderSpawn <- function(where,
   if (any(!algae$AlgType %in% algCoefs$AlgType)) {
     # Get missing algae type(s)
     missAlg <- unique(algae$AlgType[!algae$AlgType %in%
-      algCoefs$AlgType])
+                                      algCoefs$AlgType])
     # Error, and show missing type(s)
     stop("Missing algae type(s): ", paste(missAlg, collapse = ", "),
-      call. = FALSE
+         call. = FALSE
     )
   } # End if there are missing algae types
   # Get a small subset of area data
@@ -724,7 +724,7 @@ CalcUnderSpawn <- function(where,
     # size coefficients not required because all quadrats are 0.5m^2 (1.0512)
     # Algae a
     dplyr::mutate(EggDensAlg = beta * AlgLyrs^gamma * AlgProp^delta * Coef *
-      1.0512) %>%
+                    1.0512) %>%
     dplyr::group_by(
       Year, Region, StatArea, Section, LocationCode, SpawnNumber, Transect,
       Station
@@ -780,7 +780,7 @@ CalcUnderSpawn <- function(where,
       by = c("Year", "LocationCode", "SpawnNumber")
     ) %>%
     dplyr::mutate(LengthAlgae = ifelse(is.na(LengthAlgae), Length,
-      LengthAlgae
+                                       LengthAlgae
     )) %>%
     dplyr::filter(Method %in% c("Surface", "Dive")) %>%
     dplyr::left_join(y = widths, by = c(

--- a/man/CalcUnderSpawn.Rd
+++ b/man/CalcUnderSpawn.Rd
@@ -83,6 +83,7 @@ underSpawn <- CalcUnderSpawn(
   where = underLoc, a = areas, yrs = 2010:2015
 )
 underSpawn$SI
+readr::write_csv(x = underSpawn$SI, path = "under.csv")
 }
 \references{
 \insertAllCited


### PR DESCRIPTION
Easier to "weight" understory egg density. Egg density is weighted by the transect width (i.e., distance perpendicular to shore, aka transect length but spawn width) to ensure that transects contribute proportionally to the mean.